### PR TITLE
Remove argparse

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 	"License :: OSI Approved :: MIT License",
 	"Operating System :: OS Independent"
 ]
-dependencies = ["argparse>=1.4.0", "colorama>=0.4.6", "datetime>=5.2", "pycurl>=7.45.2", "pyjwt>=2.7.0", "regex>=2023.8.8", "requests>=2.31.0", "tabulate>=0.9.0", "termcolor>=1.1.0"]
+dependencies = ["colorama>=0.4.6", "datetime>=5.2", "pycurl>=7.45.2", "pyjwt>=2.7.0", "regex>=2023.8.8", "requests>=2.31.0", "tabulate>=0.9.0", "termcolor>=1.1.0"]
 
 [project.urls]
 "Homepage" = "https://github.com/ivan-sincek/forbidden"


### PR DESCRIPTION
`argparse` is a Python [standard module](https://docs.python.org/3/library/argparse.html).