### PR TITLE
chore: specify `cryptography` dep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
 	"alive-progress>=3.1.5",
 	"bot_safe_agents>=1.0",
 	"colorama>=0.4.6",
+  "cryptography>=41.0.0",
 	"pycurl>=7.45.2",
 	"pyjwt>=2.7.0",
 	"regex>=2023.8.8",


### PR DESCRIPTION
seeing some runtime issue due to missing `cryptography` dep, update pyproject to include it

```
==> /opt/homebrew/Cellar/forbidden/13.0/bin/forbidden -u https://brew.sh/ -t methods -f GET
  /opt/homebrew/Cellar/forbidden/13.0/libexec/lib/python3.13/site-packages/forbidden/utils/header.py:77: SyntaxWarning: invalid escape sequence '\:'
    matches = grep.find(("\n").join(response_headers.splitlines()), f"(?<=^{key}\:).+")
  Traceback (most recent call last):
    File "/opt/homebrew/Cellar/forbidden/13.0/bin/forbidden", line 5, in <module>
      from forbidden.main import main
    File "/opt/homebrew/Cellar/forbidden/13.0/libexec/lib/python3.13/site-packages/forbidden/main.py", line 3, in <module>
      from .utils import config, file, forbidden, general, validate
    File "/opt/homebrew/Cellar/forbidden/13.0/libexec/lib/python3.13/site-packages/forbidden/utils/forbidden.py", line 3, in <module>
      from .       import array, cookie, encode, general, grep, header, path, report, test, value
    File "/opt/homebrew/Cellar/forbidden/13.0/libexec/lib/python3.13/site-packages/forbidden/utils/value.py", line 3, in <module>
      from . import array, crypto, encode, path, url
    File "/opt/homebrew/Cellar/forbidden/13.0/libexec/lib/python3.13/site-packages/forbidden/utils/crypto.py", line 3, in <module>
      from cryptography.hazmat.primitives.asymmetric import rsa
  ModuleNotFoundError: No module named 'cryptography'
```

relates to https://github.com/Homebrew/homebrew-core/pull/210266