### PR TITLE
chore: fix invalid escape seq warning

### DIFF
--- a/src/forbidden/utils/header.py
+++ b/src/forbidden/utils/header.py
@@ -74,7 +74,7 @@ def find(response_headers: str | dict[str, str], key: str):
 				value = __value
 				break
 	else:
-		matches = grep.find(("\n").join(response_headers.splitlines()), f"(?<=^{key}\:).+")
+		matches = grep.find(("\n").join(response_headers.splitlines()), rf"(?<=^{key}\:).+")
 		if matches:
 			value = str(matches[0])
 	return value


### PR DESCRIPTION
update to fix warning as 

```
  /opt/homebrew/Cellar/forbidden/13.0/libexec/lib/python3.13/site-packages/forbidden/utils/header.py:77: SyntaxWarning: invalid escape sequence '\:'
```